### PR TITLE
Prevent armor from affecting empty slots

### DIFF
--- a/bukkit/src/main/java/com/minecraftmarket/minecraftmarket/bukkit/tasks/PurchasesTask.java
+++ b/bukkit/src/main/java/com/minecraftmarket/minecraftmarket/bukkit/tasks/PurchasesTask.java
@@ -79,7 +79,7 @@ public class PurchasesTask implements Runnable {
 
     private int getEmptySlots(PlayerInventory inventory) {
         int amount = 0;
-        for (ItemStack stack : inventory.getContents()) {
+        for (ItemStack stack : inventory.getStorageContents()) {
             if (stack == null || stack.getType() == Material.AIR) {
                 amount++;
             }


### PR DESCRIPTION
This change prevents armor slots/contents from affecting empty slot count.

When using the plugin requiring a user to have 1 empty inventory slot it currently would try to run the command if they have a full inventory but an open armor slot, which I beleive is incorrect. This fixes that.